### PR TITLE
fix(readme): missing reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const Example = props => {
     ];
 
     return (
-        <ConditionalManager observables={observables}>
+        <ConditionalManager observables={conditions}>
             {() => ({
                 loading: <Loading />,
                 error: <Error />,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const Example = props => {
     ];
 
     return (
-        <ConditionalManager observables={conditions}>
+        <ConditionalManager conditions={conditions}>
             {() => ({
                 loading: <Loading />,
                 error: <Error />,


### PR DESCRIPTION
### What Changed?
  - updated the name of `observables` to be `conditions` per the source code

### Issues Addressed:
none

No breaking changes noticed.  Seemed like the wrong identifier being used for the `conditions` prop; updated to use it.